### PR TITLE
fix: disable Ghostty dock notification badge

### DIFF
--- a/modules/home-manager/terminal/ghostty.nix
+++ b/modules/home-manager/terminal/ghostty.nix
@@ -39,6 +39,9 @@
       gtk-single-instance = true;
       window-save-state = "always";
 
+      # Bell — disable attention hint to prevent GNOME dock notification badge
+      bell-features = "no-system,no-audio,no-attention,title,no-border";
+
       # Working directory
       working-directory = "~/nixos-config";
     };


### PR DESCRIPTION
## Summary
- Disables the `attention` bell feature in Ghostty to prevent GNOME from showing a red notification counter on the dock icon
- Terminal bell events (from command completion, Claude Code sessions, etc.) were triggering the window urgent hint, which GNOME accumulates as a badge count
- Other bell features (title) kept active; audio and system bells remain disabled

## Test plan
- [ ] Rebuild NixOS on the affected machine
- [ ] Open multiple Ghostty tabs and trigger terminal bells (`echo -e '\a'`)
- [ ] Verify no red badge appears on the dock icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)